### PR TITLE
cleaning up template overrides

### DIFF
--- a/lib/helpers/misc.php
+++ b/lib/helpers/misc.php
@@ -358,9 +358,9 @@ function create_pages() {
 	);
 
 	foreach ( $wpspx_pages as $wpspx_page ) {
-		wpspx_create_page ( 
-			$wpspx_page[0], 
-			$wpspx_page[1], 
+		wpspx_create_page (
+			$wpspx_page[0],
+			$wpspx_page[1],
 			$wpspx_page[2]
 		);
 	}
@@ -444,25 +444,4 @@ function wpspx_generate_genre_list_items($shows){
 	}
 
 	return $list_items;
-}
-
-/*=============================================
-=            OVERRIDE TAX TEMPLATE            =
-=============================================*/
-add_filter('template_include','wpspx_override_tax_template');
-function wpspx_override_tax_template($template){
-    // is a specific custom taxonomy being shown?
-    $taxonomy_array = array('genres');
-    foreach ($taxonomy_array as $taxonomy_single) {
-        if ( is_tax($taxonomy_single) ) {
-            if(file_exists(trailingslashit(get_stylesheet_directory()) . '/taxonomy-'.$taxonomy_single.'.php')) {
-                $template = trailingslashit(get_stylesheet_directory()) . '/taxonomy-'.$taxonomy_single.'.php';
-            }
-            else {
-                $template = WPPSX_PLUGIN_DIR . 'lib/templates/taxonomy-'.$taxonomy_single.'.php';
-            }
-            break;
-        }
-    }
-    return $template;
 }

--- a/lib/templates/taxonomy-genres.php
+++ b/lib/templates/taxonomy-genres.php
@@ -57,7 +57,7 @@ get_header(); ?>
 				<div class="row">
 					<div class="show-filter span12">
 						<h4>Genre</h4>
-						
+
 						<hr>
 
 						<ul class="nav nav-pills show-filter" style="margin-bottom:5px;">
@@ -74,7 +74,7 @@ get_header(); ?>
 
 					<h2 id="<?php echo strtolower(str_replace(' ','-',$month)) ?>" class="month"><?php echo $month ?></h2>
 					<div class="row">
-					<?php 
+					<?php
 						$i = 0;foreach($shows as $show) {
 						$performances = $show[1];
 						$show = $show[0];
@@ -90,13 +90,13 @@ get_header(); ?>
 						endforeach;
 						if(array_sum($number_tikets) === 0) {
 							$is_sold_out = true;
-						} 
+						}
 						?>
-						<div data-tickets-left="<?php echo array_sum($number_tikets); ?>" 
+						<div data-tickets-left="<?php echo array_sum($number_tikets); ?>"
 							class="span2 show <?php echo $show->website_category; ?> <?php if($is_sold_out): ?>sold-out<?php endif; ?>">
 							<?php if($is_sold_out): ?><div class="sold-out-container"></div><?php endif; ?>
 							<a href="<?php echo get_permalink($show_id); ?>">
-								<?php 
+								<?php
 								$poster = get_the_post_thumbnail($show_id, 'poster');
 								if($poster):
 									echo $poster;
@@ -107,14 +107,14 @@ get_header(); ?>
 							<div class="info">
 								<h5><a href="<?php echo get_permalink($show_id); ?>"><?php echo $show->name ?></a></h5>
 								<p><?php echo $performances; ?></p>
-		
+
 								<ul class="genres">
 									<?php
 									$show_terms = get_the_terms($show_id, 'genres');
 									foreach ($show_terms as $show_term): ?>
 										<li><?php echo $show_term->name; ?></li>
-									<?php 
-									endforeach; 
+									<?php
+									endforeach;
 									?>
 								</ul>
 

--- a/settings.php
+++ b/settings.php
@@ -34,15 +34,15 @@ require WPPSX_PLUGIN_DIR . 'lib/shortcodes/shortcodes.php';
 
 add_action( 'admin_enqueue_scripts', 'wpspx_admin_scripts' );
 function wpspx_admin_scripts() {
-    wp_register_script( 
-        'wpspk_select', plugins_url( 'lib/assets/js', __FILE__ ) . '/wpspk.js', array( 'jquery' ), '1.0', true 
-    );
-    wp_register_style( 
-        'wpspx_admin_css', plugins_url( 'lib/assets/css', __FILE__ ) . '/wpspx.css', false, '1.0' 
-    );
-    
-    wp_enqueue_style( 'wpspx_admin_css' );
-    wp_enqueue_script( 'wpspk_select' );
+  wp_register_script(
+    'wpspk_select', plugins_url( 'lib/assets/js', __FILE__ ) . '/wpspk.js', array( 'jquery' ), '1.0', true
+  );
+  wp_register_style(
+    'wpspx_admin_css', plugins_url( 'lib/assets/css', __FILE__ ) . '/wpspx.css', false, '1.0'
+  );
+
+  wp_enqueue_style( 'wpspx_admin_css' );
+  wp_enqueue_script( 'wpspk_select' );
 }
 
 
@@ -50,28 +50,49 @@ function wpspx_admin_scripts() {
 
 add_action( 'wp_enqueue_scripts', 'wpspx_scripts' );
 function wpspx_scripts() {
-    wp_register_script(
-        'wpspk-resize', '//system.spektrix.com/'.SPEKTRIX_USER.'/website/scripts/resizeiframe.js', '', '', true 
-    );
-    wp_register_script(
-        'wpspk-viewfromseats','//system.spektrix.com/'.SPEKTRIX_USER.'/website/scripts/viewfromseats.js', '', '', true 
-    );
-    
-    wp_enqueue_script( 'wpspk-resize' );
-    wp_enqueue_script( 'wpspk-viewfromseats' );
+  wp_register_script(
+    'wpspk-resize', '//system.spektrix.com/'.SPEKTRIX_USER.'/website/scripts/resizeiframe.js', '', '', true
+  );
+  wp_register_script(
+    'wpspk-viewfromseats','//system.spektrix.com/'.SPEKTRIX_USER.'/website/scripts/viewfromseats.js', '', '', true
+  );
+
+  wp_enqueue_script( 'wpspk-resize' );
+  wp_enqueue_script( 'wpspk-viewfromseats' );
 }
 
 /*----------  load custom templates for post types  ----------*/
 
 add_filter('single_template', 'wpspx_templates');
 function wpspx_templates($single) {
-    global $wp_query, $post;
-
-    // Check for single template by post type
-    if ($post->post_type == "shows"){
-        if(file_exists(WPPSX_PLUGIN_DIR . '/lib/templates/single-shows.php'))
-            return WPPSX_PLUGIN_DIR . '/lib/templates/single-shows.php';
+  global $wp_query, $post;
+  // Allow themes to override custom template for single 'shows'.
+  if ($post->post_type == "shows") {
+    if(file_exists(STYLESHEETPATH . '/single-shows.php')) {
+      return STYLESHEETPATH . '/single-shows.php';
+    } elseif(file_exists(WPPSX_PLUGIN_DIR . '/lib/templates/single-shows.php')) {
+      return WPPSX_PLUGIN_DIR . '/lib/templates/single-shows.php';
     }
-    return $single;
+  }
+  return $single;
 }
 
+/*----------  load custom templates for taxonomies  ----------*/
+
+add_filter('template_include','wpspx_override_tax_template');
+function wpspx_override_tax_template($template){
+  // Allow themes to override custom template for 'genres' taxonomy archive.
+  $taxonomy_array = array('genres');
+  foreach ($taxonomy_array as $taxonomy_single) {
+    if ( is_tax($taxonomy_single) ) {
+      if(file_exists(STYLESHEETPATH . '/taxonomy-'.$taxonomy_single.'.php')) {
+        return STYLESHEETPATH . '/taxonomy-'.$taxonomy_single.'.php';
+      }
+      elseif(file_exists(WPPSX_PLUGIN_DIR . 'lib/templates/taxonomy-'.$taxonomy_single.'.php')) {
+        return WPPSX_PLUGIN_DIR . 'lib/templates/taxonomy-'.$taxonomy_single.'.php';
+      }
+      break;
+    }
+  }
+  return $template;
+}


### PR DESCRIPTION
Move taxonomy template override to the settings file. Allow themes to override single and taxonomy archive templates.